### PR TITLE
Fixed bug in api login response

### DIFF
--- a/googleplay.py
+++ b/googleplay.py
@@ -120,6 +120,7 @@ class GooglePlayAPI(object):
         data = data.split()
         params = {}
         for d in data:
+          if not "=" in d: continue
           k, v = d.split("=")
           params[k.strip().lower()] = v.strip()
         if "auth" in params:


### PR DESCRIPTION
Traceback (most recent call last):
  File "search.py", line 64, in <module>
    api.login(GOOGLE_LOGIN, GOOGLE_PASSWORD, AUTH_TOKEN)
  File "[...]/googleplay-api/googleplay.py", line 124, in login
    k, v = d.split("=")
ValueError: need more than 1 value to unpack
