### PR TITLE
Enable packaged installation using setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 
 # ignore downloaded apps
 *.apk
+
+# ignore build/setup artifacts
+build
+*.egg-info

--- a/googleplay.py
+++ b/googleplay.py
@@ -12,7 +12,6 @@ from google.protobuf import text_format
 from google.protobuf.message import Message, DecodeError
 
 import googleplay_pb2
-import config
 
 class LoginError(Exception):
     def __init__(self, value):
@@ -46,10 +45,6 @@ class GooglePlayAPI(object):
 
     def __init__(self, androidId=None, lang=None, debug=False): # you must use a device-associated androidId value
         self.preFetch = {}
-        if androidId == None:
-            androidId = config.ANDROID_ID
-        if lang == None:
-            lang = config.LANG
         self.androidId = androidId
         self.lang = lang
         self.debug = debug

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+
+install_requires = ['requests', 'protobuf']
+tests_require = []
+
+setup(name='googleplay-api',
+      version='1.0.0',
+      description='Google Play Unofficial Python API',
+      url='https://github.com/egirault/googleplay-api',
+      py_modules = ['googleplay', 'googleplay_pb2'],
+      author='egirault',
+      install_requires=install_requires,
+      tests_require=tests_require)


### PR DESCRIPTION
This also removes the dependency on config.py from googleplay.py. The
reason for that is because GooglePlayAPI constructor already accepts
values for the fields being obtained via `config.py`, and only the driver
wrapper scripts pass in those values from `config.py`.

By removing `config.py` dependency, it allows the package to be installed
via `easy_install`, which will only install the `googleplay` and
`googleplay_pb2` modules to the system, avoiding the need to introduce any
of the other scripts.
