### PR TITLE
Don't crash when no results are returned

### DIFF
--- a/search.py
+++ b/search.py
@@ -36,7 +36,8 @@ except:
     sys.exit(1)
 
 print_header_line()
-doc = message.doc[0]
-for c in doc.child:
+if len(message.doc) > 0:
+  doc = message.doc[0]
+  for c in doc.child:
     print_result_line(c)
 


### PR DESCRIPTION
Searching for strings that return no results crashes.

```
➜  googleplay-api git:(master) ✗ python search.py asdasda
Title;Package name;Creator;Super Dev;Price;Offer Type;Version Code;Size;Rating;Num Downloads
Traceback (most recent call last):
  File "search.py", line 39, in <module>
    doc = message.doc[0]
  File "/usr/local/lib/python2.7/dist-packages/protobuf-2.5.0-py2.7.egg/google/protobuf/internal/containers.py", line 64, in __getitem__
IndexError: list index out of range
```
